### PR TITLE
Fix :  controller 테스트에서 security 설정 잠시 내림

### DIFF
--- a/src/test/java/com/devwiki/backend/article/adapter/in/ArticleControllerTest.java
+++ b/src/test/java/com/devwiki/backend/article/adapter/in/ArticleControllerTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +26,7 @@ import com.devwiki.backend.article.domain.article.ArticleType;
 import com.devwiki.backend.article.domain.article.articleDetail.ArticleDetail;
 
 @WebMvcTest(controllers = ArticleController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class ArticleControllerTest {
 
 	@Autowired


### PR DESCRIPTION
2. spring security 는 인증, 인가를 filter 단에서 하는데, 인증정보가 없으니 401 에러를 뱉었슴.

3. 현재 테스트중에 빨간줄 뜨는게 싫어서 일단 해당 테스트에서 필터에 먼가 등록되는걸 막아놨습니다….. 만

그래도 로그인, 인증 완료되면 api 호출에 대한 테스트는 나중에 security 올려서해야 겠네여 
일단 지금은 빨간줄 싫어서 내림